### PR TITLE
Fix recursive function call

### DIFF
--- a/src/xsk_stubs.c
+++ b/src/xsk_stubs.c
@@ -323,7 +323,7 @@ CAMLprim intnat fill_queue_produce_nat(value vr, value varr, intnat pos,
 }
 
 CAMLprim value fill_queue_produce(value vr, value varr, value vpos, value vnb) {
-  return Val_int(fill_queue_produce(vr, varr, Int_val(vpos), Int_val(vnb)));
+  return Val_int(fill_queue_produce_nat(vr, varr, Int_val(vpos), Int_val(vnb)));
 }
 
 CAMLprim intnat fill_queue_produce_and_wakeup_nat(value vr, intnat sock,


### PR DESCRIPTION
Hey,
In`xsk_stubs.c` I think you made a typo by calling `fill_queue_produce` recursively instead of using the native `fill_queue_produce_nat` in the body.